### PR TITLE
Added NPM ci as part build

### DIFF
--- a/.github/workflows/package-nuget.yaml
+++ b/.github/workflows/package-nuget.yaml
@@ -35,13 +35,13 @@ jobs:
             --configuration Release `
             --output .\output\ `
             /p:AssemblyVersion=${{ steps.gitversion.outputs.assemblySemVer }} `
-            /p:AssemplyFileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }}
+            /p:AssemplyFileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }} `
+            /p:Version=${{ steps.gitversion.outputs.majorMinorPatch }}
             
       - name: Upload to nuget
         shell: pwsh
         run: |
-          dotnet nuget push `
-            .\output\*.nuget `
+          dotnet nuget push .\output\*.nupkg `
             --source https://api.nuget.org/v3/index.json `
             --api-key ${{ secrets.NUGET_API_KEY }} `
             --skip-duplicate

--- a/SagaFlow/SagaFlow.csproj
+++ b/SagaFlow/SagaFlow.csproj
@@ -45,7 +45,8 @@
     <None Include="..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
-  <Target Name="BuildSagaFlowUI" BeforeTargets="_CalculateEmbeddedFilesManifestInputs" Condition="'$(GenerateEmbeddedFilesManifest)' == 'true'">
+  <Target Name="BuildSagaFlowUI" BeforeTargets="DispatchToInnerBuilds" Condition="'$(GenerateEmbeddedFilesManifest)' == 'true'">
+    <Exec WorkingDirectory="..\SagaFlow.UI\Svelte\" Condition="!Exists('..\SagaFlow.UI\Svelte\node_modules')" Command="npm ci" />
     <Exec WorkingDirectory="..\SagaFlow.UI\Svelte\" Command="npm run build" />
     <Copy SourceFiles="..\SagaFlow.UI\Svelte\dist\index.html" DestinationFolder="UI\" />
   </Target>


### PR DESCRIPTION
only if node_modules folder doesn't exist (assuming a successful npm install has executed for development builds). 
NPM ci and build moved to before target DispatchToInnerBuilds so it only run once per platform