### PR TITLE
Adding empty Pack target

### DIFF
--- a/SagaFlow.UI/SagaFlow.UI.esproj
+++ b/SagaFlow.UI/SagaFlow.UI.esproj
@@ -12,4 +12,9 @@
     <Target Name="BuildWebComponents" BeforeTargets="Build">
         <Exec Command="npm run build:web-components" />
     </Target>
+    
+    <!-- Just a stub for a pack target so dotnet pack doesn't complain -->
+    <Target Name="pack">
+        
+    </Target>
 </Project>


### PR DESCRIPTION
So when dotnet pack is called it doesn't complain the project doesn't have a target named 'pack'.