### PR TITLE
Making SagaFlow.UI reference private

### DIFF
--- a/SagaFlow/SagaFlow.csproj
+++ b/SagaFlow/SagaFlow.csproj
@@ -52,7 +52,9 @@
   
   <ItemGroup>
     <ProjectReference Include="..\SagaFlow.Interfaces\SagaFlow.Interfaces.csproj" />
-    <ProjectReference Include="..\SagaFlow.UI\SagaFlow.UI.esproj" />
+    <ProjectReference Include="..\SagaFlow.UI\SagaFlow.UI.esproj">
+      <PrivateAssets>all</PrivateAssets>
+    </ProjectReference>
   </ItemGroup>
 
   <Target Name="BuildSagaFlowUI" AfterTargets="ResolveProjectReferences" Condition="'$(GenerateEmbeddedFilesManifest)' == 'true'">


### PR DESCRIPTION
So nuget references to SagaFlow won't try to look for a SagaFlow.UI project or nuget package.