### PR TITLE
Support for suggestions for String field

### DIFF
--- a/SagaFlow.Interfaces/StringPropertySuggestionsAttribute.cs
+++ b/SagaFlow.Interfaces/StringPropertySuggestionsAttribute.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace SagaFlow.Interfaces
+{
+    /// <summary>
+    /// Associates a Resource Provider to a text property for a message.  The resulting command form will render a data
+    /// options list for the text input.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class StringPropertySuggestionsAttribute : Attribute
+    {
+        /// <summary>
+        /// Specifies the resource provider to use as the text suggestion source by type.
+        /// </summary>
+        public Type ResourceProviderType { get; set; }
+        
+        /// <summary>
+        /// Specifies the resource provider to use as the text suggestion source by name. Useful when you want to keep
+        /// you messages library loosely decoupled from your resources, if not then use the ResourceProviderType to
+        /// specify the resource provider.
+        /// </summary>
+        public string ResourceProviderName { get; set; }
+
+        public StringPropertySuggestionsAttribute()
+        {
+        }
+    }
+}

--- a/SagaFlow.UI/src/lib/CommandForm.svelte
+++ b/SagaFlow.UI/src/lib/CommandForm.svelte
@@ -11,6 +11,7 @@
         createWebComponentEventDispatcher,
         extendToGetWebComponentRoot
     } from "$lib/RootWebComponentEventDispatcher";
+    import StringParameter from "$lib/StringParameter.svelte";
     
 
     // When used as a web-component, this is required to dispatch events from the web component
@@ -115,7 +116,7 @@
                 
                 <div class="value">
                 {#if parameter.type === "String"}
-                    <input type="text" id={parameterId} name={parameterId} required={parameter.required} disabled={sendingCommand} />
+                    <StringParameter {serverKey} {parameterId} {parameter} disabled={sendingCommand} />
                 {:else if parameter.type === "Boolean"}
                     <label class="value-yes"><input type="radio" id={`${parameterId}_yes`} name={parameterId} required={parameter.required} value={true} disabled={sendingCommand}>Yes</label>
                     <label class="value-no"><input type="radio" id={`${parameterId}_no`} name={parameterId} required={parameter.required} value={false} disabled={sendingCommand}>No</label>

--- a/SagaFlow.UI/src/lib/StringParameter.svelte
+++ b/SagaFlow.UI/src/lib/StringParameter.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+    import type {Parameter, Resource} from "$lib/types";
+    import sagaFlow from "../state/SagaFlowState";
+
+    export let serverKey: string;
+    export let parameterId: string;
+    export let parameter: Parameter;
+    export let disabled: boolean = false;
+
+    let resources: Resource[] | undefined = [];
+    
+    const loadResourceSuggestions = async (resourceId: string, serverKey: string) => {
+        resources = await sagaFlow.getResources(resourceId, serverKey)
+    }
+
+    $: if (parameter.resourceListId) 
+        loadResourceSuggestions(parameter.resourceListId, serverKey);
+    
+</script>
+
+<input type="text" id={parameterId} name={parameterId} required={parameter.required} disabled={disabled} list={resources ? `${parameterId}-list` : undefined} />
+
+{#if resources}
+    <datalist id={`${parameterId}-list`}>
+        {#each resources as resource}
+            <option value={resource.name} />
+        {/each}
+    </datalist>
+{/if}
+
+<style lang="scss">
+  input {
+    padding: var(--sf-command-form-parameter-value-padding, initial);
+    font-size: var(--sf-command-form-parameter-value-font-size, initial);
+    width: var(--sf-command-form-parameter-value-width, 100%);
+    border: var(--sf-command-form-parameter-value-border, revert);
+  }
+</style>

--- a/Samples/SimpleMvcExample.Messages/BackupDatabaseServer.cs
+++ b/Samples/SimpleMvcExample.Messages/BackupDatabaseServer.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using SagaFlow.Interfaces;
 
 namespace SimpleMvcExample.Messages
 {
@@ -10,6 +11,7 @@ namespace SimpleMvcExample.Messages
         
         [DisplayName("Destination Filename")]
         [Description("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis vel turpis vel diam dignissim euismod ut non velit. Integer eget.")]
+        [StringPropertySuggestions(ResourceProviderName = "FilenameSuggestionProvider")]
         public string? DestinationFilename { get; init; }
         
         [DisplayName("Override backup")]

--- a/Samples/SimpleMvcExample/ResourceProviders/FilenameSuggestionProvider.cs
+++ b/Samples/SimpleMvcExample/ResourceProviders/FilenameSuggestionProvider.cs
@@ -1,0 +1,22 @@
+﻿using SagaFlow;
+using SimpleMvcExample.Messages.StrongTyping;
+
+namespace SimpleMvcExample.ResourceProviders;
+
+public class FilenameSuggestionProvider : IResourceListProvider<Filename, FilenameId>
+{
+    public Task<IList<Filename>> GetAll()
+    {
+        return Task.FromResult<IList<Filename>>(
+            new List<Filename>()
+            {
+                new Filename(new FilenameId(1), "backup.bak"),
+                new Filename(new FilenameId(2), "test.bak"),
+                new Filename(new FilenameId(3), "snapshot.bak"),
+            });
+    }
+}
+
+public record FilenameId(int Value) : StronglyTypedId<int>(Value);
+
+public record Filename(FilenameId Id, string Name) : IResource<FilenameId>;


### PR DESCRIPTION
Test suggests are provided via a StringPropertySuggestions attribute, which can be applied to any string property with a reference to a ResourceProvider type as the source of the suggestions.