### PR TITLE
Fix missing closing code fence in README Web Components section

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ or if you don't want to use the attached SagaFlow from the window object.
 
     sagaFlow.initialize("[custom-sagaflow-route]")
 </script>
+```
 
 #### sf-command-form - Command form
 


### PR DESCRIPTION
## Summary
Fixes a missing closing code fence (` ``` `) in the README Web Components section. The code block starting around line 127 was never closed before the next `#### sf-command-form` heading, causing the rest of the README to render as a code block.

## Changes
- Added the missing closing ` ``` ` after the `</script>` tag on line 133

---
*Devin session: https://app.devin.ai/sessions/46a771d8898e4380a2a9c92a458abfae*